### PR TITLE
feat: improve load-balancing strategy

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -24,3 +24,6 @@ RUN go install golang.org/x/tools/gopls@latest \
 
 # Set up the workspace
 WORKDIR /workspace
+
+# Enable bash completion
+RUN . /etc/bash_completion

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -24,6 +24,3 @@ RUN go install golang.org/x/tools/gopls@latest \
 
 # Set up the workspace
 WORKDIR /workspace
-
-# Enable bash completion
-RUN . /etc/bash_completion

--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,9 @@
-# Port to use for the load balancer / proxy
+# Server Configuration
+## Port to use for the load balancer / proxy
 SERVER_PORT=8080
 
-# Path to the endpoints config file
+# Configuration File
+## Path to the endpoints config file
 CONFIG_FILE="configs/endpoints.json"
 
 # CORS Configuration
@@ -33,7 +35,7 @@ REDIS_SKIP_TLS_CHECK=false
 # Health Check Configuration
 ## Amount of consecutive successful responses from the endpoint required to consider it as being healthy again
 EPHEMERAL_CHECKS_HEALTHY_THRESHOLD=3
-## Interval in seconds for ephemeral health checks (only used when HEALTH_CHECK_INTERVAL=0, default: 30)
+## Interval in seconds for ephemeral health checks (only used when HEALTH_CHECK_INTERVAL=0)
 EPHEMERAL_CHECKS_INTERVAL=30
 ## Interval in seconds between health checks (0 to disable)
 HEALTH_CHECK_INTERVAL=30
@@ -41,8 +43,16 @@ HEALTH_CHECK_INTERVAL=30
 ## Set to false to run health checks integrated with the load balancer
 STANDALONE_HEALTH_CHECKS=true
 
+# Proxy Configuration
+## Maximum number of retries for proxy requests
+PROXY_MAX_RETRIES=3
+## Total timeout for proxy requests in seconds (what the end user sees)
+PROXY_TIMEOUT=15
+## Timeout per individual retry attempt in seconds
+PROXY_TIMEOUT_PER_TRY=5
+
 # Logging Configuration
-# Log level: debug, info, warn, error, fatal, panic
+## Log level: debug, info, warn, error, fatal, panic
 LOG_LEVEL=info
 
 # Prometheus Metrics Configuration

--- a/Makefile
+++ b/Makefile
@@ -126,7 +126,7 @@ run-hc: build-hc
 .PHONY: run-lb
 run-lb: build-lb
 	@echo "Running RPC Load Balancer..."
-	./bin/aetherlay-lb
+	./bin/aetherlay-lb --metrics-port=9091
 
 # Stop services
 .PHONY: stop

--- a/Makefile
+++ b/Makefile
@@ -113,7 +113,7 @@ k8s-delete:
 run: build
 	@echo "Starting both services..."
 	./bin/aetherlay-hc &
-	./bin/aetherlay-lb &
+	./bin/aetherlay-lb --metrics-port=9091 &
 	@echo "Both services started in the background. Use 'ps' to see them."
 
 # Run health checker

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ A lightweight, low-latency RPC load balancer written in Go. It is designed to ma
 - **Round-Robin Load Balancing**: Distributes requests to available endpoints in a round-robin manner, prioritizing those with fewer requests in the last 24 hours.
 - **Intelligent Retry Logic**: Configurable retry attempts with priority-based endpoint selection (first primary endpoints, then fallbacks).
 - **Flexible Timeout Control**: Separate timeouts for overall requests and individual retry attempts.
+- **Rate Limit Recovery**: Safe rate limit detection and recovery with exponential backoff strategies per endpoint, to avoid making things worse when a provider is rate-limiting you.
 - **Health Checks**: Regularly checks the health of upstream endpoints and updates their status in Redis.
 - **Standalone Health Checker**: Optional standalone health checker service for efficient multi-pod deployments.
 - **Static Configuration**: Loads RPC endpoint configurations from a static JSON file.
@@ -136,6 +137,7 @@ The load balancer implements intelligent retry logic with configurable timeouts:
 | `--health-check-interval`              | `30`                                                            | Health check interval in seconds                                                         |
 | `--log-level`                          | `info`                                                          | Set the log level. Valid options are: `debug`, `info`, `warn`, `error`, `fatal`, `panic` |
 | `--metrics-enabled`                    | `true`                                                          | Whether to enable Prometheus metrics                                                     |
+| `--metrics-port`                       | `9090`                                                          | Port for the Prometheus metrics server                                                   |
 | `--proxy-retries`                      | `3`                                                             | Maximum number of retries for proxy requests                                             |
 | `--proxy-timeout`                      | `15`                                                            | Total timeout for proxy requests in seconds                                              |
 | `--proxy-timeout-per-try`              | `5`                                                             | Timeout per individual retry attempt in seconds                                          |
@@ -164,6 +166,7 @@ The load balancer implements intelligent retry logic with configurable timeouts:
 | `HEALTH_CHECK_INTERVAL`              | `30`                                                            | Health check interval in seconds                                                                                                                                                  |
 | `LOG_LEVEL`                          | `info`                                                          | Set the log level                                                                                                                                                                 |
 | `METRICS_ENABLED`                    | `true`                                                          | Whether to enable Prometheus metrics                                                                                                                                              |
+| `METRICS_PORT`                       | `9090`                                                          | Port for the Prometheus metrics server                                                                            |
 | `PROXY_MAX_RETRIES`                  | `3`                                                             | Maximum number of retries for proxy requests                                                                                                                                      |
 | `PROXY_TIMEOUT`                      | `15`                                                            | Total timeout for proxy requests in seconds                                                                                                                                       |
 | `PROXY_TIMEOUT_PER_TRY`              | `5`                                                             | Timeout per individual retry attempt in seconds                                                                                                                                   |
@@ -211,6 +214,77 @@ For production deployments with multiple load balancer pods, use the standalone 
 - **Multiple Load Balancer Pods**: Scale independently without health check overhead
 - **Resource Efficiency**: Reduces RPC endpoint usage
 - **Better Separation of Concerns**: Health monitoring isolated from request handling
+
+## Rate Limit Recovery
+
+Ætherlay includes intelligent rate limit detection and recovery mechanisms to handle upstream provider rate limits gracefully. This system automatically detects when endpoints are rate-limited and implements recovery strategies to restore service.
+
+### How Rate Limit Recovery Works
+
+1. **Detection**: When a request returns a rate limit error (HTTP 429), the endpoint is automatically marked as rate-limited.
+2. **Retries with "backoff"**: The system tries to reach the endpoint only after waiting for a specific amount of time, defined as a backoff, which is configurable by the user.  This wait period increases each time, relative to another user-defined parameter (the backoff multiplier).
+3. **Automatic recovery**: The system will reintroduce the endpoint back into the load balancing pool after a certain amount of successful consecutive requests. Users can specify how many consecutive requests are required for endpoints to be marked again as healthy.
+4. **Per-endpoint configuration**: Each endpoint can have its own rate limit recovery strategy tailored to the provider's limits. You can also simply rely on the system's defaults, which have been carefully set.
+
+### Configuration Parameters
+
+Rate limit recovery is configured per endpoint in your `endpoints.json` file:
+
+```json
+{
+  "mainnet": {
+    "provider-1": {
+      "provider": "example",
+      "role": "primary",
+      "type": "archive",
+      "http_url": "https://api.example.com",
+      "rate_limit_recovery": {
+        "backoff_multiplier": 2.0,
+        "initial_backoff": 300,
+        "max_backoff": 3600,
+        "max_retries": 10,
+        "required_successes": 3,
+        "reset_after": 86400
+      }
+    }
+  }
+}
+```
+
+#### Parameters:
+
+- **`backoff_multiplier`** (`float`): Exponential multiplier for backoff time (e.g., 2.0 doubles the wait time each attempt).
+- **`initial_backoff`** (`int`): Initial backoff time in seconds before the first recovery attempt.
+- **`max_backoff`** (`int`): Maximum backoff time in seconds (limits exponential growth).
+- **`max_retries`** (`int`): Maximum number of recovery attempts before giving up until `reset_after`.
+- **`required_successes`** (`int`): Number of consecutive successes needed to mark the endpoint as healthy.
+- **`reset_after`** (`int`): Time in seconds after which to reset the backoff state and start fresh.
+
+### Recovery Strategy Examples
+
+**Conservative**:
+```json
+"rate_limit_recovery": {
+  "backoff_multiplier": 4.0,
+  "initial_backoff": 300,
+  "max_backoff": 3600,
+  "max_retries": 5,
+  "required_successes": 3,
+  "reset_after": 86400
+}
+```
+
+**Aggressive**:
+```json
+"rate_limit_recovery": {
+  "backoff_multiplier": 1.5,
+  "initial_backoff": 60,
+  "max_retries": 20,
+  "max_backoff": 600,
+  "required_successes": 1,
+  "reset_after": 86400
+}
+```
 
 ## Prometheus Metrics
 
@@ -269,4 +343,4 @@ This project is licensed under the GNU Affero General Public License v3.0 (AGPL-
 
 You may use, modify, and distribute this software under the terms of the AGPL-3.0. See the LICENSE file for details.
 
-**TL;DR:** The AGPL-3.0 ensures that all changes and derivative works must also be licensed under AGPL-3.0, and that **attribution is preserved**. If you run a modified version as a network service, you must make the source code available to users. The code is provided **as-is**, without warranties.
+**TL;DR:** The AGPL-3.0 ensures that all changes and derivative works must also be licensed under AGPL-3.0, and that **attribution is preserved**. If you run a modified version as a network service, you must make the source code available to users. This code is provided **as-is**, without warranties.

--- a/configs/endpoints-example.json
+++ b/configs/endpoints-example.json
@@ -4,7 +4,14 @@
       "provider": "llama",
       "role": "primary",
       "type": "full",
-      "http_url": "https://eth.llamarpc.com"
+      "http_url": "https://eth.llamarpc.com",
+      "rate_limit_recovery": {
+        "backoff_multiplier": 2.0,
+        "initial_backoff": 300,
+        "max_attempts": 10,
+        "max_backoff": 3600,
+        "reset_after": 86400
+      }
     },
     "drpc-1": {
       "provider": "drpc",
@@ -42,14 +49,28 @@
       "role": "primary",
       "type": "archive",
       "http_url": "https://base-mainnet.g.alchemy.com/v2/${ALCHEMY_API_KEY}",
-      "ws_url": "wss://base-mainnet.g.alchemy.com/v2/${ALCHEMY_API_KEY}"
+      "ws_url": "wss://base-mainnet.g.alchemy.com/v2/${ALCHEMY_API_KEY}",
+      "rate_limit_recovery": {
+        "backoff_multiplier": 2.0,
+        "initial_backoff": 300,
+        "max_attempts": 10,
+        "max_backoff": 3600,
+        "reset_after": 86400
+      }
     },
     "infura-staging": {
       "provider": "infura",
       "role": "primary",
       "type": "archive",
       "http_url": "https://base-mainnet.infura.io/v3/${INFURA_API_KEY}",
-      "ws_url": "wss://base-mainnet.infura.io/ws/v3/${INFURA_API_KEY}"
+      "ws_url": "wss://base-mainnet.infura.io/ws/v3/${INFURA_API_KEY}",
+      "rate_limit_recovery": {
+        "backoff_multiplier": 2.0,
+        "initial_backoff": 300,
+        "max_attempts": 10,
+        "max_backoff": 3600,
+        "reset_after": 86400
+      }
     }
   }
 }

--- a/configs/endpoints-example.json
+++ b/configs/endpoints-example.json
@@ -7,10 +7,11 @@
       "http_url": "https://eth.llamarpc.com",
       "rate_limit_recovery": {
         "backoff_multiplier": 2.0,
-        "initial_backoff": 300,
-        "max_attempts": 10,
-        "max_backoff": 3600,
-        "reset_after": 86400
+        "initial_backoff": 30,
+        "max_backoff": 300,
+        "max_retries": 10,
+        "required_successes": 3,
+        "reset_after": 3600
       }
     },
     "drpc-1": {
@@ -52,10 +53,11 @@
       "ws_url": "wss://base-mainnet.g.alchemy.com/v2/${ALCHEMY_API_KEY}",
       "rate_limit_recovery": {
         "backoff_multiplier": 2.0,
-        "initial_backoff": 300,
-        "max_attempts": 10,
-        "max_backoff": 3600,
-        "reset_after": 86400
+        "initial_backoff": 30,
+        "max_backoff": 300,
+        "max_retries": 10,
+        "required_successes": 3,
+        "reset_after": 3600
       }
     },
     "infura-staging": {
@@ -66,10 +68,11 @@
       "ws_url": "wss://base-mainnet.infura.io/ws/v3/${INFURA_API_KEY}",
       "rate_limit_recovery": {
         "backoff_multiplier": 2.0,
-        "initial_backoff": 300,
-        "max_attempts": 10,
-        "max_backoff": 3600,
-        "reset_after": 86400
+        "initial_backoff": 30,
+        "max_backoff": 300,
+        "max_retries": 10,
+        "required_successes": 3,
+        "reset_after": 3600
       }
     }
   }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -12,7 +12,7 @@ type RateLimitRecovery struct {
 	MaxBackoff        int     `json:"max_backoff"`        // Maximum backoff time in seconds
 	MaxRetries        int     `json:"max_retries"`        // Maximum number of recovery attempts
 	RequiredSuccesses int     `json:"required_successes"` // Number of consecutive successes needed to mark as recovered
-	ResetAfter        int     `json:"reset_after"`        // Time in seconds after which to reset backoff and retry from scratch
+	ResetAfter        int     `json:"reset_after"`        // Time in seconds after which to reset backoff and start from scratch
 }
 
 // Endpoint represents a single RPC endpoint configuration.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -7,9 +7,12 @@ import (
 
 // RateLimitRecovery represents the configuration for rate limit recovery
 type RateLimitRecovery struct {
-	CheckInterval     int `json:"check_interval"`      // Interval between recovery attempts in seconds  
-	MaxRetries        int `json:"max_retries"`         // Maximum number of recovery attempts
-	RequiredSuccesses int `json:"required_successes"`  // Number of consecutive successes needed to mark as recovered
+	BackoffMultiplier float64 `json:"backoff_multiplier"`   // Multiplier for exponential backoff (e.g., 2.0)
+	InitialBackoff    int     `json:"initial_backoff"`      // Initial backoff time in seconds
+	MaxBackoff        int     `json:"max_backoff"`          // Maximum backoff time in seconds
+	MaxRetries        int     `json:"max_retries"`          // Maximum number of recovery attempts
+	RequiredSuccesses int     `json:"required_successes"`   // Number of consecutive successes needed to mark as recovered
+	ResetAfter        int     `json:"reset_after"`          // Time in seconds after which to reset backoff and retry from scratch
 }
 
 // Endpoint represents a single RPC endpoint configuration.
@@ -119,8 +122,11 @@ func (c *Config) GetFallbackEndpoints(chain string) []Endpoint {
 // DefaultRateLimitRecovery returns the default rate limit recovery configuration
 func DefaultRateLimitRecovery() RateLimitRecovery {
 	return RateLimitRecovery{
-		CheckInterval:     60,  // Check every minute
-		MaxRetries:        10,  // Up to 10 recovery attempts
-		RequiredSuccesses: 3,   // Need 3 consecutive successes
+		BackoffMultiplier: 2.0,   // Double the backoff each time
+		InitialBackoff:    60,    // Start with 60 seconds
+		MaxBackoff:        7200,  // Cap at 2 hours
+		MaxRetries:        10,    // Up to 10 recovery attempts
+		RequiredSuccesses: 3,     // Need 3 consecutive successes
+		ResetAfter:        86400, // Reset backoff after 1 day
 	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -5,14 +5,22 @@ import (
 	"os"
 )
 
+// RateLimitRecovery represents the configuration for rate limit recovery
+type RateLimitRecovery struct {
+	CheckInterval     int `json:"check_interval"`      // Interval between recovery attempts in seconds  
+	MaxRetries        int `json:"max_retries"`         // Maximum number of recovery attempts
+	RequiredSuccesses int `json:"required_successes"`  // Number of consecutive successes needed to mark as recovered
+}
+
 // Endpoint represents a single RPC endpoint configuration.
 // It contains all the necessary information to connect to and use an RPC provider.
 type Endpoint struct {
-	Provider string `json:"provider"` // Name of the RPC provider (e.g., "alchemy", "infura")
-	Role     string `json:"role"`     // Role of the endpoint: "primary" or "fallback"
-	Type     string `json:"type"`     // Type of node: "full" or "archive"
-	HTTPURL  string `json:"http_url"` // HTTP/HTTPS URL for RPC requests
-	WSURL    string `json:"ws_url"`   // WebSocket URL for real-time connections
+	Provider           string             `json:"provider"`             // Name of the RPC provider (e.g., "alchemy", "infura")
+	RateLimitRecovery  *RateLimitRecovery `json:"rate_limit_recovery"`  // Rate limit recovery configuration (optional)
+	Role               string             `json:"role"`                 // Role of the endpoint: "primary" or "fallback"
+	Type               string             `json:"type"`                 // Type of node: "full" or "archive"
+	HTTPURL            string             `json:"http_url"`             // HTTP/HTTPS URL for RPC requests
+	WSURL              string             `json:"ws_url"`               // WebSocket URL for real-time connections
 }
 
 // ChainEndpoints represents all endpoints for a specific blockchain.
@@ -106,4 +114,13 @@ func (c *Config) GetFallbackEndpoints(chain string) []Endpoint {
 		}
 	}
 	return fallbackEndpoints
+}
+
+// DefaultRateLimitRecovery returns the default rate limit recovery configuration
+func DefaultRateLimitRecovery() RateLimitRecovery {
+	return RateLimitRecovery{
+		CheckInterval:     60,  // Check every minute
+		MaxRetries:        10,  // Up to 10 recovery attempts
+		RequiredSuccesses: 3,   // Need 3 consecutive successes
+	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -7,23 +7,23 @@ import (
 
 // RateLimitRecovery represents the configuration for rate limit recovery
 type RateLimitRecovery struct {
-	BackoffMultiplier float64 `json:"backoff_multiplier"`   // Multiplier for exponential backoff (e.g., 2.0)
-	InitialBackoff    int     `json:"initial_backoff"`      // Initial backoff time in seconds
-	MaxBackoff        int     `json:"max_backoff"`          // Maximum backoff time in seconds
-	MaxRetries        int     `json:"max_retries"`          // Maximum number of recovery attempts
-	RequiredSuccesses int     `json:"required_successes"`   // Number of consecutive successes needed to mark as recovered
-	ResetAfter        int     `json:"reset_after"`          // Time in seconds after which to reset backoff and retry from scratch
+	BackoffMultiplier float64 `json:"backoff_multiplier"` // Multiplier for exponential backoff (e.g., 2.0)
+	InitialBackoff    int     `json:"initial_backoff"`    // Initial backoff time in seconds
+	MaxBackoff        int     `json:"max_backoff"`        // Maximum backoff time in seconds
+	MaxRetries        int     `json:"max_retries"`        // Maximum number of recovery attempts
+	RequiredSuccesses int     `json:"required_successes"` // Number of consecutive successes needed to mark as recovered
+	ResetAfter        int     `json:"reset_after"`        // Time in seconds after which to reset backoff and retry from scratch
 }
 
 // Endpoint represents a single RPC endpoint configuration.
 // It contains all the necessary information to connect to and use an RPC provider.
 type Endpoint struct {
-	Provider           string             `json:"provider"`             // Name of the RPC provider (e.g., "alchemy", "infura")
-	RateLimitRecovery  *RateLimitRecovery `json:"rate_limit_recovery"`  // Rate limit recovery configuration (optional)
-	Role               string             `json:"role"`                 // Role of the endpoint: "primary" or "fallback"
-	Type               string             `json:"type"`                 // Type of node: "full" or "archive"
-	HTTPURL            string             `json:"http_url"`             // HTTP/HTTPS URL for RPC requests
-	WSURL              string             `json:"ws_url"`               // WebSocket URL for real-time connections
+	Provider          string             `json:"provider"`            // Name of the RPC provider (e.g., "alchemy", "infura")
+	RateLimitRecovery *RateLimitRecovery `json:"rate_limit_recovery"` // Rate limit recovery configuration (optional)
+	Role              string             `json:"role"`                // Role of the endpoint: "primary" or "fallback"
+	Type              string             `json:"type"`                // Type of node: "full" or "archive"
+	HTTPURL           string             `json:"http_url"`            // HTTP/HTTPS URL for RPC requests
+	WSURL             string             `json:"ws_url"`              // WebSocket URL for real-time connections
 }
 
 // ChainEndpoints represents all endpoints for a specific blockchain.
@@ -123,10 +123,10 @@ func (c *Config) GetFallbackEndpoints(chain string) []Endpoint {
 func DefaultRateLimitRecovery() RateLimitRecovery {
 	return RateLimitRecovery{
 		BackoffMultiplier: 2.0,   // Double the backoff each time
-		InitialBackoff:    60,    // Start with 60 seconds
+		InitialBackoff:    300,   // Start with 300 seconds
 		MaxBackoff:        7200,  // Cap at 2 hours
 		MaxRetries:        10,    // Up to 10 recovery attempts
-		RequiredSuccesses: 3,     // Need 3 consecutive successes
+		RequiredSuccesses: 2,     // Need 2 consecutive successes to mark the endpoint as recovered
 		ResetAfter:        86400, // Reset backoff after 1 day
 	}
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -154,8 +154,16 @@ func TestLoadConfigInvalidJSON(t *testing.T) {
 func TestDefaultRateLimitRecovery(t *testing.T) {
 	config := DefaultRateLimitRecovery()
 
-	if config.CheckInterval != 60 {
-		t.Errorf("Expected CheckInterval to be 60, got %d", config.CheckInterval)
+	if config.BackoffMultiplier != 2.0 {
+		t.Errorf("Expected BackoffMultiplier to be 2.0, got %f", config.BackoffMultiplier)
+	}
+
+	if config.InitialBackoff != 60 {
+		t.Errorf("Expected InitialBackoff to be 60, got %d", config.InitialBackoff)
+	}
+
+	if config.MaxBackoff != 7200 {
+		t.Errorf("Expected MaxBackoff to be 7200, got %d", config.MaxBackoff)
 	}
 
 	if config.MaxRetries != 10 {
@@ -165,17 +173,32 @@ func TestDefaultRateLimitRecovery(t *testing.T) {
 	if config.RequiredSuccesses != 3 {
 		t.Errorf("Expected RequiredSuccesses to be 3, got %d", config.RequiredSuccesses)
 	}
+
+	if config.ResetAfter != 86400 {
+		t.Errorf("Expected ResetAfter to be 86400, got %d", config.ResetAfter)
+	}
 }
 
 func TestRateLimitRecoveryStructFields(t *testing.T) {
 	recovery := RateLimitRecovery{
-		CheckInterval:     120,
+		BackoffMultiplier: 1.5,
+		InitialBackoff:    30,
+		MaxBackoff:        600,
 		MaxRetries:        5,
 		RequiredSuccesses: 2,
+		ResetAfter:        3600,
 	}
 
-	if recovery.CheckInterval != 120 {
-		t.Errorf("Expected CheckInterval to be 120, got %d", recovery.CheckInterval)
+	if recovery.BackoffMultiplier != 1.5 {
+		t.Errorf("Expected BackoffMultiplier to be 1.5, got %f", recovery.BackoffMultiplier)
+	}
+
+	if recovery.InitialBackoff != 30 {
+		t.Errorf("Expected InitialBackoff to be 30, got %d", recovery.InitialBackoff)
+	}
+
+	if recovery.MaxBackoff != 600 {
+		t.Errorf("Expected MaxBackoff to be 600, got %d", recovery.MaxBackoff)
 	}
 
 	if recovery.MaxRetries != 5 {
@@ -185,13 +208,20 @@ func TestRateLimitRecoveryStructFields(t *testing.T) {
 	if recovery.RequiredSuccesses != 2 {
 		t.Errorf("Expected RequiredSuccesses to be 2, got %d", recovery.RequiredSuccesses)
 	}
+
+	if recovery.ResetAfter != 3600 {
+		t.Errorf("Expected ResetAfter to be 3600, got %d", recovery.ResetAfter)
+	}
 }
 
 func TestEndpointWithRateLimitRecovery(t *testing.T) {
 	recovery := &RateLimitRecovery{
-		CheckInterval:     30,
+		BackoffMultiplier: 1.8,
+		InitialBackoff:    45,
+		MaxBackoff:        900,
 		MaxRetries:        3,
 		RequiredSuccesses: 1,
+		ResetAfter:        7200,
 	}
 
 	endpoint := Endpoint{
@@ -207,8 +237,16 @@ func TestEndpointWithRateLimitRecovery(t *testing.T) {
 		t.Fatal("Expected rate limit recovery configuration to be set")
 	}
 
-	if endpoint.RateLimitRecovery.CheckInterval != 30 {
-		t.Errorf("Expected CheckInterval to be 30, got %d", endpoint.RateLimitRecovery.CheckInterval)
+	if endpoint.RateLimitRecovery.BackoffMultiplier != 1.8 {
+		t.Errorf("Expected BackoffMultiplier to be 1.8, got %f", endpoint.RateLimitRecovery.BackoffMultiplier)
+	}
+
+	if endpoint.RateLimitRecovery.InitialBackoff != 45 {
+		t.Errorf("Expected InitialBackoff to be 45, got %d", endpoint.RateLimitRecovery.InitialBackoff)
+	}
+
+	if endpoint.RateLimitRecovery.MaxBackoff != 900 {
+		t.Errorf("Expected MaxBackoff to be 900, got %d", endpoint.RateLimitRecovery.MaxBackoff)
 	}
 
 	if endpoint.RateLimitRecovery.MaxRetries != 3 {
@@ -217,5 +255,9 @@ func TestEndpointWithRateLimitRecovery(t *testing.T) {
 
 	if endpoint.RateLimitRecovery.RequiredSuccesses != 1 {
 		t.Errorf("Expected RequiredSuccesses to be 1, got %d", endpoint.RateLimitRecovery.RequiredSuccesses)
+	}
+
+	if endpoint.RateLimitRecovery.ResetAfter != 7200 {
+		t.Errorf("Expected ResetAfter to be 7200, got %d", endpoint.RateLimitRecovery.ResetAfter)
 	}
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -150,3 +150,72 @@ func TestLoadConfigInvalidJSON(t *testing.T) {
 		t.Fatal("Should return error for invalid JSON")
 	}
 }
+
+func TestDefaultRateLimitRecovery(t *testing.T) {
+	config := DefaultRateLimitRecovery()
+
+	if config.CheckInterval != 60 {
+		t.Errorf("Expected CheckInterval to be 60, got %d", config.CheckInterval)
+	}
+
+	if config.MaxRetries != 10 {
+		t.Errorf("Expected MaxRetries to be 10, got %d", config.MaxRetries)
+	}
+
+	if config.RequiredSuccesses != 3 {
+		t.Errorf("Expected RequiredSuccesses to be 3, got %d", config.RequiredSuccesses)
+	}
+}
+
+func TestRateLimitRecoveryStructFields(t *testing.T) {
+	recovery := RateLimitRecovery{
+		CheckInterval:     120,
+		MaxRetries:        5,
+		RequiredSuccesses: 2,
+	}
+
+	if recovery.CheckInterval != 120 {
+		t.Errorf("Expected CheckInterval to be 120, got %d", recovery.CheckInterval)
+	}
+
+	if recovery.MaxRetries != 5 {
+		t.Errorf("Expected MaxRetries to be 5, got %d", recovery.MaxRetries)
+	}
+
+	if recovery.RequiredSuccesses != 2 {
+		t.Errorf("Expected RequiredSuccesses to be 2, got %d", recovery.RequiredSuccesses)
+	}
+}
+
+func TestEndpointWithRateLimitRecovery(t *testing.T) {
+	recovery := &RateLimitRecovery{
+		CheckInterval:     30,
+		MaxRetries:        3,
+		RequiredSuccesses: 1,
+	}
+
+	endpoint := Endpoint{
+		Provider:          "test-provider",
+		RateLimitRecovery: recovery,
+		Role:              "primary",
+		Type:              "full",
+		HTTPURL:           "http://test.com",
+		WSURL:             "ws://test.com",
+	}
+
+	if endpoint.RateLimitRecovery == nil {
+		t.Fatal("Expected rate limit recovery configuration to be set")
+	}
+
+	if endpoint.RateLimitRecovery.CheckInterval != 30 {
+		t.Errorf("Expected CheckInterval to be 30, got %d", endpoint.RateLimitRecovery.CheckInterval)
+	}
+
+	if endpoint.RateLimitRecovery.MaxRetries != 3 {
+		t.Errorf("Expected MaxRetries to be 3, got %d", endpoint.RateLimitRecovery.MaxRetries)
+	}
+
+	if endpoint.RateLimitRecovery.RequiredSuccesses != 1 {
+		t.Errorf("Expected RequiredSuccesses to be 1, got %d", endpoint.RateLimitRecovery.RequiredSuccesses)
+	}
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -158,8 +158,8 @@ func TestDefaultRateLimitRecovery(t *testing.T) {
 		t.Errorf("Expected BackoffMultiplier to be 2.0, got %f", config.BackoffMultiplier)
 	}
 
-	if config.InitialBackoff != 60 {
-		t.Errorf("Expected InitialBackoff to be 60, got %d", config.InitialBackoff)
+	if config.InitialBackoff != 300 {
+		t.Errorf("Expected InitialBackoff to be 300, got %d", config.InitialBackoff)
 	}
 
 	if config.MaxBackoff != 7200 {
@@ -170,8 +170,8 @@ func TestDefaultRateLimitRecovery(t *testing.T) {
 		t.Errorf("Expected MaxRetries to be 10, got %d", config.MaxRetries)
 	}
 
-	if config.RequiredSuccesses != 3 {
-		t.Errorf("Expected RequiredSuccesses to be 3, got %d", config.RequiredSuccesses)
+	if config.RequiredSuccesses != 2 {
+		t.Errorf("Expected RequiredSuccesses to be 2, got %d", config.RequiredSuccesses)
 	}
 
 	if config.ResetAfter != 86400 {

--- a/internal/cors/cors.go
+++ b/internal/cors/cors.go
@@ -2,8 +2,6 @@ package cors
 
 import (
 	"net/http"
-
-	"github.com/rs/zerolog/log"
 )
 
 // Middleware creates a CORS middleware with explicit configuration values.
@@ -19,11 +17,6 @@ func Middleware(next http.Handler, corsHeaders, corsMethods, corsOrigin string) 
 		if w.Header().Get("Access-Control-Allow-Origin") == "" {
 			w.Header().Set("Access-Control-Allow-Origin", corsOrigin)
 		}
-
-		// Log the headers and their values for debugging single requests
-		log.Debug().Str("Access-Control-Allow-Headers", corsHeaders).Msg("CORS config -")
-		log.Debug().Str("Access-Control-Allow-Methods", corsMethods).Msg("CORS config -")
-		log.Debug().Str("Access-Control-Allow-Origin", corsOrigin).Msg("CORS config -")
 
 		// Handle preflight OPTIONS request
 		if r.Method == "OPTIONS" {

--- a/internal/health/checker.go
+++ b/internal/health/checker.go
@@ -94,7 +94,7 @@ func (c *Checker) StartEphemeralChecks(ctx context.Context) {
 		}
 	}
 
-	ticker := time.NewTicker(5 * time.Second) // How often to scan for unhealthy endpoints
+	ticker := time.NewTicker(c.ephemeralChecksInterval) // How often to scan for unhealthy endpoints
 	defer ticker.Stop()
 
 	for {
@@ -309,7 +309,7 @@ func (c *Checker) checkHTTPHealth(ctx context.Context, chain, endpointID string,
 				Str("endpoint_id", endpointID).
 				Int("status_code", resp.StatusCode).
 				Msg("Health check detected 429, handing over to rate limit handler")
-			
+
 			c.HandleRateLimitFunc(chain, endpointID, "http")
 			return healthy // Return early, rate limit handler takes over
 		}
@@ -363,7 +363,7 @@ func (c *Checker) checkWSHealth(ctx context.Context, chain, endpointID string, e
 	if err != nil {
 		log.Error().
 			Err(err).
-			Str("endpoint", endpoint.WSURL).
+			Str("endpoint", helpers.RedactAPIKey(endpoint.WSURL)).
 			Str("chain", chain).
 			Str("endpoint_id", endpointID).
 			Msg("WebSocket health check failed: failed to establish connection")

--- a/internal/helpers/helpers.go
+++ b/internal/helpers/helpers.go
@@ -22,6 +22,9 @@ type Config struct {
 	LogLevel                        string
 	MetricsEnabled                  bool
 	MetricsPort                     int
+	ProxyMaxRetries                 int
+	ProxyTimeout                    int
+	ProxyTimeoutPerTry              int
 	RedisHost                       string
 	RedisPass                       string
 	RedisPort                       string
@@ -46,6 +49,9 @@ func ParseFlags() *Config {
 	flag.StringVar(&config.LogLevel, "log-level", "info", "Log level (debug, info, warn, error)")
 	flag.BoolVar(&config.MetricsEnabled, "metrics-enabled", true, "Enable metrics server")
 	flag.IntVar(&config.MetricsPort, "metrics-port", 9090, "Metrics server port")
+	flag.IntVar(&config.ProxyMaxRetries, "proxy-retries", 3, "Maximum number of retries for proxy requests")
+	flag.IntVar(&config.ProxyTimeout, "proxy-timeout", 15, "Timeout for proxy requests in seconds")
+	flag.IntVar(&config.ProxyTimeoutPerTry, "proxy-timeout-per-try", 5, "Timeout per individual retry attempt in seconds")
 	flag.StringVar(&config.RedisHost, "redis-host", "localhost", "Redis host")
 	flag.StringVar(&config.RedisPass, "redis-pass", "", "Redis password")
 	flag.StringVar(&config.RedisPort, "redis-port", "6379", "Redis port")
@@ -108,6 +114,9 @@ func (c *Config) LoadConfiguration() *LoadedConfig {
 		LogLevel:                        c.GetStringValue("log-level", c.LogLevel, "LOG_LEVEL", "info"),
 		MetricsEnabled:                  c.GetBoolValue("metrics-enabled", c.MetricsEnabled, "METRICS_ENABLED", true),
 		MetricsPort:                     c.GetIntValue("metrics-port", c.MetricsPort, "METRICS_PORT", 9090),
+		ProxyMaxRetries:                 c.GetIntValue("proxy-retries", c.ProxyMaxRetries, "PROXY_MAX_RETRIES", 3),
+		ProxyTimeout:                    c.GetIntValue("proxy-timeout", c.ProxyTimeout, "PROXY_TIMEOUT", 15),
+		ProxyTimeoutPerTry:              c.GetIntValue("proxy-timeout-per-try", c.ProxyTimeoutPerTry, "PROXY_TIMEOUT_PER_TRY", 5),
 		RedisHost:                       c.GetStringValue("redis-host", c.RedisHost, "REDIS_HOST", "localhost"),
 		RedisPass:                       c.GetStringValue("redis-pass", c.RedisPass, "REDIS_PASS", ""),
 		RedisPort:                       c.GetStringValue("redis-port", c.RedisPort, "REDIS_PORT", "6379"),
@@ -130,6 +139,9 @@ type LoadedConfig struct {
 	LogLevel                        string
 	MetricsEnabled                  bool
 	MetricsPort                     int
+	ProxyMaxRetries                 int
+	ProxyTimeout                    int
+	ProxyTimeoutPerTry              int
 	RedisHost                       string
 	RedisPass                       string
 	RedisPort                       string
@@ -145,7 +157,7 @@ type LoadedConfig struct {
 func getStringFromEnv(envKey, defaultValue string) string {
 	if envValue := os.Getenv(envKey); envValue != "" {
 		if strings.TrimSpace(envValue) != "" {
-			logValue := envKey
+			logValue := envValue
 			if envKey == "REDIS_PASS" {
 				logValue = "REDACTED"
 			}

--- a/internal/server/rate_limit_scheduler.go
+++ b/internal/server/rate_limit_scheduler.go
@@ -174,6 +174,10 @@ func (rls *RateLimitScheduler) performRecoveryCheck(chain, endpointID string, en
 
 	if success {
 		state.ConsecutiveSuccess++
+		if state.ConsecutiveSuccess == 1 {
+			// Reset backoff to initial value after the first successful check
+			state.CurrentBackoff = rateLimitConfig.InitialBackoff
+		}
 		log.Debug().
 			Str("chain", chain).
 			Str("endpoint", endpointID).

--- a/internal/server/rate_limit_scheduler.go
+++ b/internal/server/rate_limit_scheduler.go
@@ -1,0 +1,241 @@
+package server
+
+import (
+	"context"
+	"net/http"
+	"sync"
+	"time"
+
+	"aetherlay/internal/config"
+	"aetherlay/internal/helpers"
+	"aetherlay/internal/store"
+
+	"github.com/rs/zerolog/log"
+)
+
+// RateLimitScheduler manages recovery checks for rate-limited endpoints
+type RateLimitScheduler struct {
+	config      *config.Config
+	redisClient store.RedisClientIface
+
+	// Active monitoring tracking
+	activeMonitoring map[string]bool // key: chain:endpoint
+	mu               sync.RWMutex
+}
+
+// NewRateLimitScheduler creates a new rate limit scheduler
+func NewRateLimitScheduler(cfg *config.Config, redisClient store.RedisClientIface) *RateLimitScheduler {
+	return &RateLimitScheduler{
+		config:           cfg,
+		redisClient:      redisClient,
+		activeMonitoring: make(map[string]bool),
+	}
+}
+
+// StartMonitoring starts monitoring an endpoint for rate limit recovery
+func (rls *RateLimitScheduler) StartMonitoring(chain, endpointID string) {
+	key := chain + ":" + endpointID
+
+	rls.mu.Lock()
+	// Don't start monitoring if already active
+	if rls.activeMonitoring[key] {
+		rls.mu.Unlock()
+		log.Debug().Str("chain", chain).Str("endpoint", endpointID).Msg("Rate limit monitoring already active")
+		return
+	}
+	rls.activeMonitoring[key] = true
+	rls.mu.Unlock()
+
+	log.Info().Str("chain", chain).Str("endpoint", endpointID).Msg("Starting rate limit recovery monitoring")
+
+	// Start monitoring in a goroutine
+	go rls.monitorEndpoint(chain, endpointID)
+}
+
+// monitorEndpoint performs periodic recovery checks for a rate-limited endpoint
+func (rls *RateLimitScheduler) monitorEndpoint(chain, endpointID string) {
+	key := chain + ":" + endpointID
+
+	// Clean up monitoring flag when done
+	defer func() {
+		rls.mu.Lock()
+		delete(rls.activeMonitoring, key)
+		rls.mu.Unlock()
+		log.Debug().Str("chain", chain).Str("endpoint", endpointID).Msg("Rate limit monitoring stopped")
+	}()
+
+	// Get endpoint configuration
+	chainEndpoints, exists := rls.config.GetEndpointsForChain(chain)
+	if !exists {
+		log.Error().Str("chain", chain).Msg("Chain not found in configuration")
+		return
+	}
+
+	endpoint, exists := chainEndpoints[endpointID]
+	if !exists {
+		log.Error().Str("chain", chain).Str("endpoint", endpointID).Msg("Endpoint not found in configuration")
+		return
+	}
+
+	// Get rate limit recovery configuration
+	rateLimitConfig := config.DefaultRateLimitRecovery()
+	if endpoint.RateLimitRecovery != nil {
+		rateLimitConfig = *endpoint.RateLimitRecovery
+	}
+
+	checkInterval := time.Duration(rateLimitConfig.CheckInterval) * time.Second
+	ticker := time.NewTicker(checkInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ticker.C:
+			// Check if we should continue monitoring
+			shouldContinue, err := rls.performRecoveryCheck(chain, endpointID, endpoint, rateLimitConfig)
+			if err != nil {
+				log.Error().Err(err).Str("chain", chain).Str("endpoint", endpointID).Msg("Error during recovery check")
+				continue
+			}
+			if !shouldContinue {
+				return // Stop monitoring
+			}
+		}
+	}
+}
+
+// performRecoveryCheck performs a single recovery check for an endpoint
+func (rls *RateLimitScheduler) performRecoveryCheck(chain, endpointID string, endpoint config.Endpoint, rateLimitConfig config.RateLimitRecovery) (bool, error) {
+	// Get current rate limit state
+	state, err := rls.redisClient.GetRateLimitState(context.Background(), chain, endpointID)
+	if err != nil {
+		return false, err
+	}
+
+	// If no longer rate limited, stop monitoring
+	if !state.RateLimited {
+		log.Debug().Str("chain", chain).Str("endpoint", endpointID).Msg("Endpoint no longer rate limited, stopping monitoring")
+		return false, nil
+	}
+
+	// Check if we've exceeded max retries
+	if state.RecoveryAttempts >= rateLimitConfig.MaxRetries {
+		log.Warn().
+			Str("chain", chain).
+			Str("endpoint", endpointID).
+			Int("attempts", state.RecoveryAttempts).
+			Int("max_retries", rateLimitConfig.MaxRetries).
+			Msg("Rate limit recovery max retries exceeded, stopping monitoring")
+		return false, nil
+	}
+
+	log.Debug().Str("chain", chain).Str("endpoint", endpointID).Int("attempt", state.RecoveryAttempts+1).Msg("Performing rate limit recovery check")
+
+	// Increment recovery attempts
+	state.RecoveryAttempts++
+	state.LastRecoveryCheck = time.Now()
+
+	// Perform the health check
+	success := rls.checkEndpointHealth(endpoint)
+
+	if success {
+		state.ConsecutiveSuccess++
+		log.Debug().
+			Str("chain", chain).
+			Str("endpoint", endpointID).
+			Int("consecutive_success", state.ConsecutiveSuccess).
+			Int("required", rateLimitConfig.RequiredSuccesses).
+			Msg("Rate limit recovery check succeeded")
+
+		// Check if we have enough consecutive successes
+		if state.ConsecutiveSuccess >= rateLimitConfig.RequiredSuccesses {
+			// Mark as recovered
+			state.RateLimited = false
+			state.RecoveryAttempts = 0
+			state.ConsecutiveSuccess = 0
+
+			// Update endpoint status to healthy
+			endpointStatus, err := rls.redisClient.GetEndpointStatus(context.Background(), chain, endpointID)
+			if err != nil {
+				log.Error().Err(err).Str("chain", chain).Str("endpoint", endpointID).Msg("Failed to get endpoint status")
+			} else {
+				if endpoint.HTTPURL != "" {
+					endpointStatus.HealthyHTTP = true
+				}
+				if endpoint.WSURL != "" {
+					endpointStatus.HealthyWS = true
+				}
+
+				if err := rls.redisClient.UpdateEndpointStatus(context.Background(), chain, endpointID, *endpointStatus); err != nil {
+					log.Error().Err(err).Str("chain", chain).Str("endpoint", endpointID).Msg("Failed to update endpoint status")
+				} else {
+					log.Info().
+						Str("chain", chain).
+						Str("endpoint", endpointID).
+						Int("successful_checks", rateLimitConfig.RequiredSuccesses).
+						Msg("Endpoint recovered from rate limiting")
+				}
+			}
+
+			// Save state and stop monitoring
+			if err := rls.redisClient.SetRateLimitState(context.Background(), chain, endpointID, *state); err != nil {
+				log.Error().Err(err).Str("chain", chain).Str("endpoint", endpointID).Msg("Failed to save recovery state")
+			}
+			return false, nil // Stop monitoring
+		}
+	} else {
+		// Reset consecutive success count on failure
+		state.ConsecutiveSuccess = 0
+		log.Debug().Str("chain", chain).Str("endpoint", endpointID).Msg("Rate limit recovery check failed, resetting consecutive success count")
+	}
+
+	// Save updated state
+	if err := rls.redisClient.SetRateLimitState(context.Background(), chain, endpointID, *state); err != nil {
+		log.Error().Err(err).Str("chain", chain).Str("endpoint", endpointID).Msg("Failed to save rate limit state")
+		return false, err
+	}
+
+	return true, nil // Continue monitoring
+}
+
+// checkEndpointHealth performs a simple HTTP health check on the endpoint
+func (rls *RateLimitScheduler) checkEndpointHealth(endpoint config.Endpoint) bool {
+	if endpoint.HTTPURL == "" {
+		return false
+	}
+
+	// Create a simple HTTP client with timeout
+	client := &http.Client{
+		Timeout: 10 * time.Second,
+	}
+
+	// Create a simple POST request (similar to what the proxy would do)
+	req, err := http.NewRequest("POST", endpoint.HTTPURL, http.NoBody)
+	if err != nil {
+		log.Debug().Err(err).Str("url", helpers.RedactAPIKey(endpoint.HTTPURL)).Msg("Failed to create recovery check request")
+		return false
+	}
+
+	// Set appropriate headers
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		log.Debug().Err(err).Str("url", helpers.RedactAPIKey(endpoint.HTTPURL)).Msg("Recovery check request failed")
+		return false
+	}
+	defer resp.Body.Close()
+
+	// Consider 2xx responses as success, 429 as still rate limited, others as failure
+	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+		log.Debug().Str("url", helpers.RedactAPIKey(endpoint.HTTPURL)).Int("status", resp.StatusCode).Msg("Recovery check successful")
+		return true
+	}
+
+	if resp.StatusCode == 429 {
+		log.Debug().Str("url", helpers.RedactAPIKey(endpoint.HTTPURL)).Msg("Recovery check still rate limited")
+	} else {
+		log.Debug().Str("url", helpers.RedactAPIKey(endpoint.HTTPURL)).Int("status", resp.StatusCode).Msg("Recovery check failed with error status")
+	}
+
+	return false
+}

--- a/internal/server/rate_limit_scheduler_test.go
+++ b/internal/server/rate_limit_scheduler_test.go
@@ -1,0 +1,313 @@
+package server
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"aetherlay/internal/config"
+	"aetherlay/internal/store"
+)
+
+func TestNewRateLimitScheduler(t *testing.T) {
+	cfg := &config.Config{
+		Endpoints: map[string]config.ChainEndpoints{
+			"ethereum": {
+				"test-endpoint": config.Endpoint{
+					Provider: "test-provider",
+					Role:     "primary",
+					Type:     "full",
+					HTTPURL:  "http://test-url.com",
+				},
+			},
+		},
+	}
+
+	mockRedis := store.NewMockRedisClient()
+	scheduler := NewRateLimitScheduler(cfg, mockRedis)
+
+	if scheduler == nil {
+		t.Error("Expected scheduler to be created")
+	}
+
+	if scheduler.config != cfg {
+		t.Error("Expected config to be set")
+	}
+
+	if scheduler.redisClient != mockRedis {
+		t.Error("Expected redis client to be set")
+	}
+
+	if scheduler.activeMonitoring == nil {
+		t.Error("Expected active monitoring map to be initialized")
+	}
+}
+
+func TestStartMonitoringDoesNotDuplicate(t *testing.T) {
+	cfg := &config.Config{
+		Endpoints: map[string]config.ChainEndpoints{
+			"ethereum": {
+				"test-endpoint": config.Endpoint{
+					Provider: "test-provider",
+					Role:     "primary",
+					Type:     "full",
+					HTTPURL:  "http://test-url.com",
+				},
+			},
+		},
+	}
+
+	mockRedis := store.NewMockRedisClient()
+	scheduler := NewRateLimitScheduler(cfg, mockRedis)
+
+	// Start monitoring
+	scheduler.StartMonitoring("ethereum", "test-endpoint")
+
+	// Verify it's being monitored
+	key := "ethereum:test-endpoint"
+	scheduler.mu.RLock()
+	if !scheduler.activeMonitoring[key] {
+		t.Error("Expected endpoint to be actively monitored")
+	}
+	scheduler.mu.RUnlock()
+
+	// Start monitoring again - should not create duplicate
+	initialCount := len(scheduler.activeMonitoring)
+	scheduler.StartMonitoring("ethereum", "test-endpoint")
+
+	scheduler.mu.RLock()
+	newCount := len(scheduler.activeMonitoring)
+	scheduler.mu.RUnlock()
+
+	if newCount != initialCount {
+		t.Error("Expected duplicate monitoring to be prevented")
+	}
+}
+
+func TestCheckEndpointHealthSuccess(t *testing.T) {
+	// Create a test HTTP server that returns 200
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	cfg := &config.Config{
+		Endpoints: map[string]config.ChainEndpoints{
+			"ethereum": {
+				"test-endpoint": config.Endpoint{
+					Provider: "test-provider",
+					Role:     "primary",
+					Type:     "full",
+					HTTPURL:  server.URL,
+				},
+			},
+		},
+	}
+
+	mockRedis := store.NewMockRedisClient()
+	scheduler := NewRateLimitScheduler(cfg, mockRedis)
+
+	endpoint := cfg.Endpoints["ethereum"]["test-endpoint"]
+	healthy := scheduler.checkEndpointHealth(endpoint)
+
+	if !healthy {
+		t.Error("Expected endpoint to be healthy")
+	}
+}
+
+func TestCheckEndpointHealthRateLimited(t *testing.T) {
+	// Create a test HTTP server that returns 429
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	cfg := &config.Config{
+		Endpoints: map[string]config.ChainEndpoints{
+			"ethereum": {
+				"test-endpoint": config.Endpoint{
+					Provider: "test-provider",
+					Role:     "primary",
+					Type:     "full",
+					HTTPURL:  server.URL,
+				},
+			},
+		},
+	}
+
+	mockRedis := store.NewMockRedisClient()
+	scheduler := NewRateLimitScheduler(cfg, mockRedis)
+
+	endpoint := cfg.Endpoints["ethereum"]["test-endpoint"]
+	healthy := scheduler.checkEndpointHealth(endpoint)
+
+	if healthy {
+		t.Error("Expected endpoint to be unhealthy due to rate limiting")
+	}
+}
+
+func TestPerformRecoveryCheckStopsWhenNotRateLimited(t *testing.T) {
+	cfg := &config.Config{
+		Endpoints: map[string]config.ChainEndpoints{
+			"ethereum": {
+				"test-endpoint": config.Endpoint{
+					Provider: "test-provider",
+					Role:     "primary",
+					Type:     "full",
+					HTTPURL:  "http://test-url.com",
+				},
+			},
+		},
+	}
+
+	mockRedis := store.NewMockRedisClient()
+	
+	// Set up endpoint as not rate limited
+	state := store.RateLimitState{
+		RateLimited:        false,
+		RecoveryAttempts:   0,
+		LastRecoveryCheck:  time.Time{},
+		ConsecutiveSuccess: 0,
+	}
+	mockRedis.SetRateLimitState(context.Background(), "ethereum", "test-endpoint", state)
+
+	scheduler := NewRateLimitScheduler(cfg, mockRedis)
+
+	endpoint := cfg.Endpoints["ethereum"]["test-endpoint"]
+	rateLimitConfig := config.DefaultRateLimitRecovery()
+
+	shouldContinue, err := scheduler.performRecoveryCheck("ethereum", "test-endpoint", endpoint, rateLimitConfig)
+
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+
+	if shouldContinue {
+		t.Error("Expected monitoring to stop when endpoint is not rate limited")
+	}
+}
+
+func TestPerformRecoveryCheckStopsAfterMaxRetries(t *testing.T) {
+	cfg := &config.Config{
+		Endpoints: map[string]config.ChainEndpoints{
+			"ethereum": {
+				"test-endpoint": config.Endpoint{
+					Provider: "test-provider",
+					Role:     "primary",
+					Type:     "full",
+					HTTPURL:  "http://test-url.com",
+				},
+			},
+		},
+	}
+
+	mockRedis := store.NewMockRedisClient()
+	
+	// Set up endpoint as rate limited with max retries reached
+	state := store.RateLimitState{
+		RateLimited:        true,
+		RecoveryAttempts:   5, // At max retries
+		LastRecoveryCheck:  time.Now(),
+		ConsecutiveSuccess: 0,
+	}
+	mockRedis.SetRateLimitState(context.Background(), "ethereum", "test-endpoint", state)
+
+	scheduler := NewRateLimitScheduler(cfg, mockRedis)
+
+	endpoint := cfg.Endpoints["ethereum"]["test-endpoint"]
+	rateLimitConfig := config.RateLimitRecovery{
+		CheckInterval:     60,
+		MaxRetries:        5, // Same as recovery attempts
+		RequiredSuccesses: 3,
+	}
+
+	shouldContinue, err := scheduler.performRecoveryCheck("ethereum", "test-endpoint", endpoint, rateLimitConfig)
+
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+
+	if shouldContinue {
+		t.Error("Expected monitoring to stop when max retries reached")
+	}
+}
+
+func TestPerformRecoveryCheckRecovery(t *testing.T) {
+	// Create a test HTTP server that returns 200
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	cfg := &config.Config{
+		Endpoints: map[string]config.ChainEndpoints{
+			"ethereum": {
+				"test-endpoint": config.Endpoint{
+					Provider: "test-provider",
+					Role:     "primary",
+					Type:     "full",
+					HTTPURL:  server.URL,
+				},
+			},
+		},
+	}
+
+	mockRedis := store.NewMockRedisClient()
+	
+	// Set up initial endpoint status
+	endpointStatus := store.EndpointStatus{
+		HasHTTP:     true,
+		HealthyHTTP: false, // Currently unhealthy
+	}
+	mockRedis.UpdateEndpointStatus(context.Background(), "ethereum", "test-endpoint", endpointStatus)
+
+	// Set up endpoint as rate limited with enough consecutive successes to recover
+	state := store.RateLimitState{
+		RateLimited:        true,
+		RecoveryAttempts:   2,
+		LastRecoveryCheck:  time.Now(),
+		ConsecutiveSuccess: 2, // One away from recovery
+	}
+	mockRedis.SetRateLimitState(context.Background(), "ethereum", "test-endpoint", state)
+
+	scheduler := NewRateLimitScheduler(cfg, mockRedis)
+
+	endpoint := cfg.Endpoints["ethereum"]["test-endpoint"]
+	rateLimitConfig := config.RateLimitRecovery{
+		CheckInterval:     60,
+		MaxRetries:        10,
+		RequiredSuccesses: 3, // Need 3 successes, we have 2
+	}
+
+	shouldContinue, err := scheduler.performRecoveryCheck("ethereum", "test-endpoint", endpoint, rateLimitConfig)
+
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+
+	if shouldContinue {
+		t.Error("Expected monitoring to stop after recovery")
+	}
+
+	// Verify endpoint was marked as recovered
+	finalState, err := mockRedis.GetRateLimitState(context.Background(), "ethereum", "test-endpoint")
+	if err != nil {
+		t.Fatalf("Failed to get final rate limit state: %v", err)
+	}
+
+	if finalState.RateLimited {
+		t.Error("Expected endpoint to be marked as not rate limited after recovery")
+	}
+
+	// Verify endpoint status was updated
+	finalStatus, err := mockRedis.GetEndpointStatus(context.Background(), "ethereum", "test-endpoint")
+	if err != nil {
+		t.Fatalf("Failed to get final endpoint status: %v", err)
+	}
+
+	if !finalStatus.HealthyHTTP {
+		t.Error("Expected endpoint to be marked as healthy after recovery")
+	}
+}

--- a/internal/server/rate_limit_scheduler_test.go
+++ b/internal/server/rate_limit_scheduler_test.go
@@ -29,7 +29,7 @@ func TestNewRateLimitScheduler(t *testing.T) {
 	scheduler := NewRateLimitScheduler(cfg, mockRedis)
 
 	if scheduler == nil {
-		t.Error("Expected scheduler to be created")
+		t.Fatal("Expected scheduler to be created")
 	}
 
 	if scheduler.config != cfg {

--- a/internal/store/redis.go
+++ b/internal/store/redis.go
@@ -151,6 +151,8 @@ func (r *RedisClient) GetEndpointStatus(ctx context.Context, chain, endpoint str
 // RateLimitState represents the rate limit recovery state for an endpoint
 type RateLimitState struct {
 	ConsecutiveSuccess int       `json:"consecutive_success"` // Number of consecutive successful recovery checks
+	CurrentBackoff     int       `json:"current_backoff"`     // Current backoff time in seconds
+	FirstRateLimited   time.Time `json:"first_rate_limited"`  // When the endpoint was first rate limited (for reset_after)
 	LastRecoveryCheck  time.Time `json:"last_recovery_check"` // When the last recovery check was performed
 	RateLimited        bool      `json:"rate_limited"`        // Whether the endpoint is currently rate limited
 	RecoveryAttempts   int       `json:"recovery_attempts"`   // Number of recovery attempts made
@@ -234,6 +236,8 @@ func (r *RedisClient) GetRateLimitState(ctx context.Context, chain, endpoint str
 		// Return default state if not found
 		return &RateLimitState{
 			ConsecutiveSuccess: 0,
+			CurrentBackoff:     0,
+			FirstRateLimited:   time.Time{},
 			LastRecoveryCheck:  time.Time{},
 			RateLimited:        false,
 			RecoveryAttempts:   0,

--- a/internal/store/redis.go
+++ b/internal/store/redis.go
@@ -11,13 +11,14 @@ import (
 
 const (
 	// Key prefixes for Redis storage
-	healthPrefix   = "health:"
-	metricsPrefix  = "metrics:"
-	proxyRequests  = "proxy_requests"
-	healthRequests = "health_requests"
-	requests24hKey = "requests_24h"
-	requests1mKey  = "requests_1m"
-	requestsAllKey = "requests_all"
+	healthPrefix    = "health:"
+	metricsPrefix   = "metrics:"
+	rateLimitPrefix = "rate_limit:"
+	proxyRequests   = "proxy_requests"
+	healthRequests  = "health_requests"
+	requests24hKey  = "requests_24h"
+	requests1mKey   = "requests_1m"
+	requestsAllKey  = "requests_all"
 )
 
 // EndpointStatus represents the health status and metrics of an endpoint.
@@ -58,6 +59,8 @@ type RedisClientIface interface {
 	UpdateEndpointStatus(ctx context.Context, chain, endpoint string, status EndpointStatus) error
 	IncrementRequestCount(ctx context.Context, chain, endpoint string, requestType string) error
 	GetCombinedRequestCounts(ctx context.Context, chain, endpoint string) (int64, int64, int64, error)
+	GetRateLimitState(ctx context.Context, chain, endpoint string) (*RateLimitState, error)
+	SetRateLimitState(ctx context.Context, chain, endpoint string, state RateLimitState) error
 	Ping(ctx context.Context) error
 	Close() error
 }
@@ -145,6 +148,14 @@ func (r *RedisClient) GetEndpointStatus(ctx context.Context, chain, endpoint str
 	return &status, nil
 }
 
+// RateLimitState represents the rate limit recovery state for an endpoint
+type RateLimitState struct {
+	ConsecutiveSuccess int       `json:"consecutive_success"` // Number of consecutive successful recovery checks
+	LastRecoveryCheck  time.Time `json:"last_recovery_check"` // When the last recovery check was performed
+	RateLimited        bool      `json:"rate_limited"`        // Whether the endpoint is currently rate limited
+	RecoveryAttempts   int       `json:"recovery_attempts"`   // Number of recovery attempts made
+}
+
 // IncrementRequestCount increments the request count for an endpoint in Redis.
 // It maintains separate counters for 24-hour, 1-month, and lifetime requests.
 // The 24-hour and 1-month counters have automatic expiration set.
@@ -213,4 +224,39 @@ func (r *RedisClient) GetCombinedRequestCounts(ctx context.Context, chain, endpo
 
 	// Return combined counts
 	return p24h + h24h, p1m + h1m, pAll + hAll, nil
+}
+
+// GetRateLimitState retrieves the rate limit state for an endpoint from Redis
+func (r *RedisClient) GetRateLimitState(ctx context.Context, chain, endpoint string) (*RateLimitState, error) {
+	key := rateLimitPrefix + chain + ":" + endpoint
+	data, err := r.client.Get(ctx, key).Bytes()
+	if err == redis.Nil {
+		// Return default state if not found
+		return &RateLimitState{
+			ConsecutiveSuccess: 0,
+			LastRecoveryCheck:  time.Time{},
+			RateLimited:        false,
+			RecoveryAttempts:   0,
+		}, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	var state RateLimitState
+	if err := json.Unmarshal(data, &state); err != nil {
+		return nil, err
+	}
+	return &state, nil
+}
+
+// SetRateLimitState updates the rate limit state for an endpoint in Redis
+func (r *RedisClient) SetRateLimitState(ctx context.Context, chain, endpoint string, state RateLimitState) error {
+	key := rateLimitPrefix + chain + ":" + endpoint
+	data, err := json.Marshal(state)
+	if err != nil {
+		return err
+	}
+	// Set with 24-hour expiration to prevent indefinite storage of old rate limit states
+	return r.client.Set(ctx, key, data, 24*time.Hour).Err()
 }

--- a/internal/store/testutils.go
+++ b/internal/store/testutils.go
@@ -151,10 +151,12 @@ func (m *MockRedisClient) GetRateLimitState(_ context.Context, chain, endpoint s
 	state, ok := m.rateLimitStates[key]
 	if !ok {
 		return &RateLimitState{
+			ConsecutiveSuccess: 0,
+			CurrentBackoff:     0,
+			FirstRateLimited:   time.Time{},
+			LastRecoveryCheck:  time.Time{},
 			RateLimited:        false,
 			RecoveryAttempts:   0,
-			LastRecoveryCheck:  time.Time{},
-			ConsecutiveSuccess: 0,
 		}, nil
 	}
 	return state, nil

--- a/services/health-checker/main.go
+++ b/services/health-checker/main.go
@@ -115,7 +115,7 @@ func RunHealthChecker(
 		if testExitAfterSetup {
 			return
 		}
-		log.Info().Msg("HEALTH_CHECK_INTERVAL=0: Only ephemeral checks will run when needed.")
+		log.Info().Msg("HEALTH_CHECK_INTERVAL=0, only ephemeral checks will run when needed.")
 		go checker.StartEphemeralChecks(ctx)
 		stop := make(chan os.Signal, 1)
 		signal.Notify(stop, os.Interrupt, syscall.SIGTERM)

--- a/services/health-checker/main.go
+++ b/services/health-checker/main.go
@@ -33,6 +33,37 @@ var testCheckerPatch func(*health.Checker)
 // testExitAfterSetup is a test hook to exit main after setup in tests
 var testExitAfterSetup bool
 
+// createStandaloneRateLimitHandler creates a simple rate limit handler for the standalone health checker
+func createStandaloneRateLimitHandler(redisClient store.RedisClientIface) func(chain, endpointID, protocol string) {
+	return func(chain, endpointID, protocol string) {
+		log.Debug().Str("chain", chain).Str("endpoint", endpointID).Str("protocol", protocol).Msg("Standalone health checker detected rate limit")
+
+		// Get current rate limit state
+		state, err := redisClient.GetRateLimitState(context.Background(), chain, endpointID)
+		if err != nil {
+			log.Error().Err(err).Str("chain", chain).Str("endpoint", endpointID).Msg("Failed to get rate limit state in standalone health checker")
+			return
+		}
+
+		// Mark as rate limited but don't start recovery scheduling (that's for the main load balancer)
+		now := time.Now()
+		state.RateLimited = true
+		state.LastRecoveryCheck = now
+		
+		// Set first rate limited time if this is the first time
+		if state.FirstRateLimited.IsZero() {
+			state.FirstRateLimited = now
+		}
+
+		if err := redisClient.SetRateLimitState(context.Background(), chain, endpointID, *state); err != nil {
+			log.Error().Err(err).Str("chain", chain).Str("endpoint", endpointID).Msg("Failed to set rate limit state in standalone health checker")
+			return
+		}
+
+		log.Info().Str("chain", chain).Str("endpoint", endpointID).Str("protocol", protocol).Msg("Standalone health checker marked endpoint as rate limited")
+	}
+}
+
 // RunHealthChecker runs the health checker service with the given configuration.
 func RunHealthChecker(
 	configFile string,
@@ -103,6 +134,10 @@ func RunHealthChecker(
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	checker := health.NewChecker(cfg, redisClient, time.Duration(healthCheckInterval)*time.Second, time.Duration(ephemeralChecksInterval)*time.Second, ephemeralChecksHealthyThreshold)
+	
+	// Set up simple rate limit handler for standalone health checker
+	checker.HandleRateLimitFunc = createStandaloneRateLimitHandler(redisClient)
+	
 	if testCheckerPatch != nil {
 		testCheckerPatch(checker)
 	}

--- a/services/load-balancer/main.go
+++ b/services/load-balancer/main.go
@@ -78,6 +78,9 @@ func main() {
 		log.Fatal().Err(err).Msg("Failed to connect to Redis")
 	}
 
+	// Initialize and start the server
+	srv := server.NewServer(cfg, redisClient, appConfig)
+
 	// Configure regular health checks based on the value of standaloneHealthChecks
 	if !appConfig.StandaloneHealthChecks {
 		if appConfig.HealthCheckInterval > 0 {
@@ -85,15 +88,15 @@ func main() {
 			defer cancel()
 			checker := health.NewChecker(cfg, redisClient, time.Duration(appConfig.HealthCheckInterval)*time.Second, time.Duration(appConfig.EphemeralChecksInterval)*time.Second, appConfig.EphemeralChecksHealthyThreshold)
 
+			// Connect health checker to server's rate limit handler
+			checker.HandleRateLimitFunc = srv.GetRateLimitHandler()
+
 			log.Info().Int("interval_seconds", appConfig.HealthCheckInterval).Msg("Starting integrated health check service")
 			go checker.Start(ctx)
 		}
 	} else if appConfig.StandaloneHealthChecks {
 		log.Info().Msg("Standalone health checks enabled (STANDALONE_HEALTH_CHECKS=true). Using external health checker service.")
 	}
-
-	// Initialize and start the server
-	srv := server.NewServer(cfg, redisClient, appConfig)
 	srv.AddMiddleware(func(next http.Handler) http.Handler {
 		return cors.Middleware(next, appConfig.CorsHeaders, appConfig.CorsMethods, appConfig.CorsOrigin)
 	})

--- a/services/load-balancer/main.go
+++ b/services/load-balancer/main.go
@@ -93,7 +93,7 @@ func main() {
 	}
 
 	// Initialize and start the server
-	srv := server.NewServer(cfg, redisClient)
+	srv := server.NewServer(cfg, redisClient, appConfig)
 	srv.AddMiddleware(func(next http.Handler) http.Handler {
 		return cors.Middleware(next, appConfig.CorsHeaders, appConfig.CorsMethods, appConfig.CorsOrigin)
 	})


### PR DESCRIPTION
* Added retries for the proxy. This allows a user request to succeed even when the proxy has to try different endpoints before it gets to a working one.
* Improved handling of rate-limited endpoints. This prevents the service from making things worse by constantly trying to send requests to an endpoint that is rate-limiting it.
* Some other unrelated fixes/improvements got into this PR, but those are minor changes.