### PR TITLE
fix: make sure endpoint_health_status gauge is properly set

### DIFF
--- a/internal/health/checker.go
+++ b/internal/health/checker.go
@@ -354,7 +354,7 @@ func (c *Checker) checkEndpoint(ctx context.Context, chain, endpointID string, e
 	rateLimitState, err := c.valkeyClient.GetRateLimitState(ctx, chain, endpointID)
 	if err == nil && rateLimitState.RateLimited {
 		log.Debug().Str("chain", chain).Str("endpoint_id", endpointID).Msg("Skipping health check for rate-limited endpoint")
-		c.updateHealthMetrics(chain, endpointID, false)
+		c.recordHealthCheckSkipped(chain, endpointID)
 		return
 	}
 
@@ -644,6 +644,13 @@ func (c *Checker) updateHealthMetrics(chain, endpointID string, healthy bool) {
 		metrics.EndpointHealthStatus.WithLabelValues(chain, endpointID).Set(0)
 		metrics.HealthCheckTotal.WithLabelValues(chain, endpointID, "failure").Inc()
 	}
+}
+
+// recordHealthCheckSkipped marks the endpoint as unhealthy in the gauge without
+// recording a failure, so rate-limited skips are distinguishable from real failures.
+func (c *Checker) recordHealthCheckSkipped(chain, endpointID string) {
+	metrics.EndpointHealthStatus.WithLabelValues(chain, endpointID).Set(0)
+	metrics.HealthCheckTotal.WithLabelValues(chain, endpointID, "skipped").Inc()
 }
 
 // incrementHealthRequestCount increments the health request count and logs errors

--- a/internal/health/checker.go
+++ b/internal/health/checker.go
@@ -354,6 +354,7 @@ func (c *Checker) checkEndpoint(ctx context.Context, chain, endpointID string, e
 	rateLimitState, err := c.valkeyClient.GetRateLimitState(ctx, chain, endpointID)
 	if err == nil && rateLimitState.RateLimited {
 		log.Debug().Str("chain", chain).Str("endpoint_id", endpointID).Msg("Skipping health check for rate-limited endpoint")
+		c.updateHealthMetrics(chain, endpointID, false)
 		return
 	}
 

--- a/internal/health/checker.go
+++ b/internal/health/checker.go
@@ -354,7 +354,7 @@ func (c *Checker) checkEndpoint(ctx context.Context, chain, endpointID string, e
 	rateLimitState, err := c.valkeyClient.GetRateLimitState(ctx, chain, endpointID)
 	if err == nil && rateLimitState.RateLimited {
 		log.Debug().Str("chain", chain).Str("endpoint_id", endpointID).Msg("Skipping health check for rate-limited endpoint")
-		c.recordHealthCheckSkipped(chain, endpointID)
+		c.recordHealthCheckFailed(chain, endpointID)
 		return
 	}
 
@@ -646,11 +646,11 @@ func (c *Checker) updateHealthMetrics(chain, endpointID string, healthy bool) {
 	}
 }
 
-// recordHealthCheckSkipped marks the endpoint as unhealthy in the gauge without
-// recording a failure, so rate-limited skips are distinguishable from real failures.
-func (c *Checker) recordHealthCheckSkipped(chain, endpointID string) {
+// recordHealthCheckFailed marks the endpoint as unhealthy in the gauge and
+// increments the failure counter for rate-limited endpoints.
+func (c *Checker) recordHealthCheckFailed(chain, endpointID string) {
 	metrics.EndpointHealthStatus.WithLabelValues(chain, endpointID).Set(0)
-	metrics.HealthCheckTotal.WithLabelValues(chain, endpointID, "skipped").Inc()
+	metrics.HealthCheckTotal.WithLabelValues(chain, endpointID, "failed").Inc()
 }
 
 // incrementHealthRequestCount increments the health request count and logs errors

--- a/internal/health/checker.go
+++ b/internal/health/checker.go
@@ -650,7 +650,7 @@ func (c *Checker) updateHealthMetrics(chain, endpointID string, healthy bool) {
 // increments the failure counter for rate-limited endpoints.
 func (c *Checker) recordHealthCheckFailed(chain, endpointID string) {
 	metrics.EndpointHealthStatus.WithLabelValues(chain, endpointID).Set(0)
-	metrics.HealthCheckTotal.WithLabelValues(chain, endpointID, "failed").Inc()
+	metrics.HealthCheckTotal.WithLabelValues(chain, endpointID, "failure").Inc()
 }
 
 // incrementHealthRequestCount increments the health request count and logs errors


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Rate-limited endpoints are now recorded as distinct "skipped" health-check outcomes and marked unhealthy in metrics, so health dashboards and totals reflect skipped checks separately from other failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->