### PR TITLE
fix: Improve how we deal with WS closures

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1186,7 +1186,10 @@ func (s *Server) defaultForwardRequestWithBodyFunc(w http.ResponseWriter, ctx co
 
 // proxyWebSocketCopy copies messages from src to dst, forwarding close frames
 // to the destination so both peers receive a proper WebSocket close handshake.
-func proxyWebSocketCopy(src, dst *websocket.Conn) error {
+// It returns the first error and a bool indicating whether the error came from
+// reading src (true) or writing to dst (false), so callers can attribute the
+// failure to the correct peer.
+func proxyWebSocketCopy(src, dst *websocket.Conn) (error, bool) {
 	for {
 		msgType, msg, err := src.ReadMessage()
 		if err != nil {
@@ -1202,10 +1205,10 @@ func proxyWebSocketCopy(src, dst *websocket.Conn) error {
 				_ = dst.WriteMessage(websocket.CloseMessage,
 					websocket.FormatCloseMessage(code, closeErr.Text))
 			}
-			return err
+			return err, true // error came from reading src
 		}
 		if err := dst.WriteMessage(msgType, msg); err != nil {
-			return err
+			return err, false // error came from writing to dst
 		}
 	}
 }
@@ -1307,30 +1310,48 @@ func (s *Server) defaultProxyWebSocket(w http.ResponseWriter, r *http.Request, b
 		backendConn.Close()
 		return err
 	}
-	// Proxy messages in both directions using directional channels so we can
-	// distinguish backend-initiated disconnects from client-initiated ones.
+	// Proxy messages in both directions. Each goroutine reports (err, readErr)
+	// via proxyWebSocketCopy, where readErr=true means the error came from
+	// reading the source peer. Using separate channels lets us combine the
+	// goroutine identity with readErr to attribute failures precisely:
+	//
+	//   backendErrc + readErr=true  → backend's ReadMessage failed  → backend at fault
+	//   backendErrc + readErr=false → client's WriteMessage failed  → client at fault
+	//   clientErrc  + readErr=true  → client's ReadMessage failed   → client at fault
+	//   clientErrc  + readErr=false → backend's WriteMessage failed → backend at fault
 	type wsResult struct {
-		err         error
-		fromBackend bool
+		err     error
+		readErr bool // true = error from src.ReadMessage; false = from dst.WriteMessage
 	}
-	errc := make(chan wsResult, 2)
+	backendErrc := make(chan wsResult, 1)
+	clientErrc := make(chan wsResult, 1)
 	go func() {
-		err := proxyWebSocketCopy(backendConn, clientConn)
-		errc <- wsResult{err, true}
+		err, isRead := proxyWebSocketCopy(backendConn, clientConn)
+		backendErrc <- wsResult{err, isRead}
 	}()
 	go func() {
-		err := proxyWebSocketCopy(clientConn, backendConn)
-		errc <- wsResult{err, false}
+		err, isRead := proxyWebSocketCopy(clientConn, backendConn)
+		clientErrc <- wsResult{err, isRead}
 	}()
-	// Wait for one direction to fail/close, then immediately close both
-	// connections so the other goroutine unblocks and finishes cleanly.
-	first := <-errc
-	clientConn.Close()
-	backendConn.Close()
-	<-errc // wait for the second goroutine to finish
+	// Wait for the first side to stop, then close both connections so the
+	// other goroutine unblocks and can be drained.
+	var first wsResult
+	var backendAtFault bool
+	select {
+	case first = <-backendErrc:
+		backendAtFault = first.readErr // read from backend failed → backend at fault
+		clientConn.Close()
+		backendConn.Close()
+		<-clientErrc
+	case first = <-clientErrc:
+		backendAtFault = !first.readErr // write to backend failed → backend at fault
+		clientConn.Close()
+		backendConn.Close()
+		<-backendErrc
+	}
 
 	if first.err != nil {
-		if first.fromBackend {
+		if backendAtFault {
 			if closeErr, ok := first.err.(*websocket.CloseError); ok {
 				switch closeErr.Code {
 				case websocket.CloseNormalClosure, // 1000: graceful, e.g. connection time limit

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1307,39 +1307,66 @@ func (s *Server) defaultProxyWebSocket(w http.ResponseWriter, r *http.Request, b
 		backendConn.Close()
 		return err
 	}
-	// Proxy messages in both directions
-	errc := make(chan error, 2)
-	go func() {
-		err := proxyWebSocketCopy(clientConn, backendConn)
-		errc <- err
-	}()
+	// Proxy messages in both directions using directional channels so we can
+	// distinguish backend-initiated disconnects from client-initiated ones.
+	type wsResult struct {
+		err         error
+		fromBackend bool
+	}
+	errc := make(chan wsResult, 2)
 	go func() {
 		err := proxyWebSocketCopy(backendConn, clientConn)
-		errc <- err
+		errc <- wsResult{err, true}
+	}()
+	go func() {
+		err := proxyWebSocketCopy(clientConn, backendConn)
+		errc <- wsResult{err, false}
 	}()
 	// Wait for one direction to fail/close, then immediately close both
 	// connections so the other goroutine unblocks and finishes cleanly.
-	err = <-errc
+	first := <-errc
 	clientConn.Close()
 	backendConn.Close()
 	<-errc // wait for the second goroutine to finish
 
-	// Mark endpoint as unhealthy for WS if error is not a normal closure
-	if err != nil {
-		if isExpectedWSClose(err) {
-			if closeErr, ok := err.(*websocket.CloseError); ok && closeErr.Code == websocket.CloseAbnormalClosure {
-				log.Debug().Err(err).Str("endpoint", helpers.RedactAPIKey(backendURL)).Msg("WebSocket connection closed abnormally (1006), not counting as failure")
-			} else {
-				log.Debug().Err(err).Str("endpoint", helpers.RedactAPIKey(backendURL)).Msg("WebSocket connection closed normally")
+	if first.err != nil {
+		if first.fromBackend {
+			if closeErr, ok := first.err.(*websocket.CloseError); ok {
+				switch closeErr.Code {
+				case websocket.CloseNormalClosure, // 1000: graceful, e.g. connection time limit
+					websocket.CloseGoingAway,        // 1001: planned shutdown
+					websocket.CloseNoStatusReceived: // 1005: no close code (ambiguous, treat as graceful)
+					log.Debug().Err(first.err).Int("code", int(closeErr.Code)).
+						Str("endpoint", helpers.RedactAPIKey(backendURL)).
+						Msg("Backend closed WebSocket normally")
+					return nil // graceful backend close is not a failure; caller marks success
+				default:
+					// 1006 (TCP drop), 1011 (internal error), and any other code
+					// indicate the backend terminated unexpectedly.
+					log.Debug().Err(first.err).Int("code", int(closeErr.Code)).
+						Str("endpoint", helpers.RedactAPIKey(backendURL)).
+						Msg("Backend closed WebSocket with unexpected code, counting as failure")
+					if chain, endpointID, found := s.findChainAndEndpointByURL(backendURL); found {
+						s.markEndpointUnhealthyProtocol(chain, endpointID, "ws")
+					}
+					return first.err // caller: isExpectedWSClose(1006)=true prevents retry
+				}
 			}
-			return nil
+			// Non-close-frame error from backend (network error, read timeout, etc.)
+			log.Debug().Err(first.err).
+				Str("endpoint", helpers.RedactAPIKey(backendURL)).
+				Msg("Backend WebSocket connection error, counting as failure")
+			if chain, endpointID, found := s.findChainAndEndpointByURL(backendURL); found {
+				s.markEndpointUnhealthyProtocol(chain, endpointID, "ws")
+			}
+			return first.err
 		}
-		if chain, endpointID, found := s.findChainAndEndpointByURL(backendURL); found {
-			s.markEndpointUnhealthyProtocol(chain, endpointID, "ws")
-		}
+		// Client closed the connection. Any reason is fine, backend was healthy.
+		log.Debug().Err(first.err).
+			Str("endpoint", helpers.RedactAPIKey(backendURL)).
+			Msg("Client closed WebSocket connection")
 	}
-
-	return err
+	return nil
 }
 
 // GetRateLimitHandler returns the rate limit handler function for the health checker

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -13,6 +13,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"aetherlay/internal/cache"
@@ -1189,7 +1190,11 @@ func (s *Server) defaultForwardRequestWithBodyFunc(w http.ResponseWriter, ctx co
 // It returns the first error and a bool indicating whether the error came from
 // reading src (true) or writing to dst (false), so callers can attribute the
 // failure to the correct peer.
-func proxyWebSocketCopy(src, dst *websocket.Conn) (error, bool) {
+// proxyWebSocketCopy copies messages from src to dst until an error occurs.
+// closeSent, when non-nil, is set to true immediately before forwarding a close
+// frame to dst. Callers use this to detect echoed close frames and avoid
+// misattributing a backend-initiated close to the client.
+func proxyWebSocketCopy(src, dst *websocket.Conn, closeSent *atomic.Bool) (error, bool) {
 	for {
 		msgType, msg, err := src.ReadMessage()
 		if err != nil {
@@ -1201,6 +1206,9 @@ func proxyWebSocketCopy(src, dst *websocket.Conn) (error, bool) {
 					websocket.CloseAbnormalClosure,
 					websocket.CloseTLSHandshake:
 					code = websocket.CloseGoingAway
+				}
+				if closeSent != nil {
+					closeSent.Store(true)
 				}
 				_ = dst.WriteMessage(websocket.CloseMessage,
 					websocket.FormatCloseMessage(code, closeErr.Text))
@@ -1323,14 +1331,20 @@ func (s *Server) defaultProxyWebSocket(w http.ResponseWriter, r *http.Request, b
 		err     error
 		readErr bool // true = error from src.ReadMessage; false = from dst.WriteMessage
 	}
+	// closeSentToClient is set to true by the backend-reading goroutine
+	// immediately before it forwards a close frame to the client. If the
+	// client-reading goroutine then fires with a read error, that close is
+	// the client echoing our frame back — not a genuine client-initiated
+	// close — so the backend remains at fault.
+	var closeSentToClient atomic.Bool
 	backendErrc := make(chan wsResult, 1)
 	clientErrc := make(chan wsResult, 1)
 	go func() {
-		err, isRead := proxyWebSocketCopy(backendConn, clientConn)
+		err, isRead := proxyWebSocketCopy(backendConn, clientConn, &closeSentToClient)
 		backendErrc <- wsResult{err, isRead}
 	}()
 	go func() {
-		err, isRead := proxyWebSocketCopy(clientConn, backendConn)
+		err, isRead := proxyWebSocketCopy(clientConn, backendConn, nil)
 		clientErrc <- wsResult{err, isRead}
 	}()
 	// Wait for the first side to stop, then close both connections so the
@@ -1339,12 +1353,18 @@ func (s *Server) defaultProxyWebSocket(w http.ResponseWriter, r *http.Request, b
 	var backendAtFault bool
 	select {
 	case first = <-backendErrc:
-		backendAtFault = first.readErr // read from backend failed → backend at fault
+		backendAtFault = first.readErr // read from backend failed: backend at fault
 		clientConn.Close()
 		backendConn.Close()
 		<-clientErrc
 	case first = <-clientErrc:
-		backendAtFault = !first.readErr // write to backend failed → backend at fault
+		// If we already forwarded a close frame to the client, the client's
+		// close is an echo of our frame, meaning the backend initiated the close.
+		if first.readErr && closeSentToClient.Load() {
+			backendAtFault = true
+		} else {
+			backendAtFault = !first.readErr // write to backend failed: backend at fault
+		}
 		clientConn.Close()
 		backendConn.Close()
 		<-backendErrc

--- a/internal/server/ws_close_test.go
+++ b/internal/server/ws_close_test.go
@@ -1,0 +1,317 @@
+package server
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"aetherlay/internal/config"
+	"aetherlay/internal/helpers"
+	"aetherlay/internal/store"
+
+	"github.com/gorilla/websocket"
+)
+
+var testWSUpgrader = websocket.Upgrader{CheckOrigin: func(r *http.Request) bool { return true }}
+
+// newBackendWSServer creates a test WebSocket backend server. The handler
+// receives the upgraded connection and can close it however the test requires.
+func newBackendWSServer(handler func(*websocket.Conn)) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := testWSUpgrader.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		handler(conn)
+	}))
+}
+
+// newWSProxyServer creates an aetherlay server wired to a single WS endpoint
+// (backendWSURL) on chain "testchain" / endpoint "ep1", pre-seeded as healthy.
+// Thresholds are set to 1 so that a single failure/success immediately updates
+// the Valkey status, making assertions straightforward.
+func newWSProxyServer(t *testing.T, backendWSURL string) (*httptest.Server, *store.MockValkeyClient) {
+	t.Helper()
+	cfg := &config.Config{
+		Endpoints: map[string]config.ChainEndpoints{
+			"testchain": {
+				"ep1": config.Endpoint{WSURL: backendWSURL, Role: "primary", Type: "full"},
+			},
+		},
+	}
+	vk := store.NewMockValkeyClient()
+	vk.PopulateStatuses(map[string]*store.EndpointStatus{
+		"testchain:ep1": {HasWS: true, HealthyWS: true},
+	})
+	appCfg := &helpers.LoadedConfig{
+		EphemeralChecksEnabled:   true,
+		EndpointFailureThreshold: 1,
+		EndpointSuccessThreshold: 1,
+		ProxyMaxRetries:          1,
+		ProxyTimeout:             5,
+		ProxyTimeoutPerTry:       5,
+	}
+	srv := NewServer(cfg, vk, appCfg)
+	ts := httptest.NewServer(srv.router)
+	t.Cleanup(ts.Close)
+	return ts, vk
+}
+
+// dialTestWS connects a gorilla WebSocket client to ts at the given path.
+func dialTestWS(t *testing.T, ts *httptest.Server, path string) *websocket.Conn {
+	t.Helper()
+	u := "ws" + strings.TrimPrefix(ts.URL, "http") + path
+	conn, _, err := websocket.DefaultDialer.Dial(u, nil)
+	if err != nil {
+		t.Fatalf("dial %s: %v", u, err)
+	}
+	return conn
+}
+
+// wsCloseCode reads from conn until it receives a close error and returns the
+// WebSocket close code. Returns -1 if the connection closed without a WS close frame.
+func wsCloseCode(conn *websocket.Conn) int {
+	for {
+		_, _, err := conn.ReadMessage()
+		if err == nil {
+			continue
+		}
+		if ce, ok := err.(*websocket.CloseError); ok {
+			return ce.Code
+		}
+		return -1
+	}
+}
+
+// wsIsUnhealthy reports whether ep1 on testchain is currently WS-unhealthy in vk.
+func wsIsUnhealthy(t *testing.T, vk *store.MockValkeyClient) bool {
+	t.Helper()
+	status, err := vk.GetEndpointStatus(context.Background(), "testchain", "ep1")
+	if err != nil {
+		t.Fatalf("GetEndpointStatus: %v", err)
+	}
+	return !status.HealthyWS
+}
+
+// settle gives aetherlay goroutines a moment to finish processing after the
+// client observes the close.
+func settle() { time.Sleep(80 * time.Millisecond) }
+
+// --- Backend-initiated closes ---
+
+// TestWSClose_Backend_NormalClosure verifies that a clean 1000 close from the
+// backend (e.g., connection time-limit) is NOT counted as a failure.
+// The client must receive 1000 and the endpoint must remain healthy.
+func TestWSClose_Backend_NormalClosure(t *testing.T) {
+	done := make(chan struct{})
+	backend := newBackendWSServer(func(conn *websocket.Conn) {
+		defer close(done)
+		conn.WriteMessage(websocket.CloseMessage,
+			websocket.FormatCloseMessage(websocket.CloseNormalClosure, "time limit reached"))
+		time.Sleep(20 * time.Millisecond)
+		conn.Close()
+	})
+	defer backend.Close()
+
+	ts, vk := newWSProxyServer(t, "ws"+strings.TrimPrefix(backend.URL, "http"))
+	client := dialTestWS(t, ts, "/testchain")
+	defer client.Close()
+
+	code := wsCloseCode(client)
+	if code != websocket.CloseNormalClosure {
+		t.Errorf("client expected close 1000, got %d", code)
+	}
+
+	<-done
+	settle()
+
+	if wsIsUnhealthy(t, vk) {
+		t.Error("endpoint must remain healthy after backend 1000 (Normal Closure)")
+	}
+}
+
+// TestWSClose_Backend_GoingAway verifies that a 1001 close from the backend
+// (planned shutdown) is NOT counted as a failure.
+// The client must receive 1001 and the endpoint must remain healthy.
+func TestWSClose_Backend_GoingAway(t *testing.T) {
+	done := make(chan struct{})
+	backend := newBackendWSServer(func(conn *websocket.Conn) {
+		defer close(done)
+		conn.WriteMessage(websocket.CloseMessage,
+			websocket.FormatCloseMessage(websocket.CloseGoingAway, "server restarting"))
+		time.Sleep(20 * time.Millisecond)
+		conn.Close()
+	})
+	defer backend.Close()
+
+	ts, vk := newWSProxyServer(t, "ws"+strings.TrimPrefix(backend.URL, "http"))
+	client := dialTestWS(t, ts, "/testchain")
+	defer client.Close()
+
+	code := wsCloseCode(client)
+	if code != websocket.CloseGoingAway {
+		t.Errorf("client expected close 1001, got %d", code)
+	}
+
+	<-done
+	settle()
+
+	if wsIsUnhealthy(t, vk) {
+		t.Error("endpoint must remain healthy after backend 1001 (Going Away)")
+	}
+}
+
+// TestWSClose_Backend_AbnormalClosure verifies that a TCP drop (no WS close
+// frame, gorilla reports 1006) from the backend IS counted as a failure.
+// The client must receive 1001 (remapped per RFC 6455) and the endpoint must
+// be marked WS-unhealthy.
+func TestWSClose_Backend_AbnormalClosure(t *testing.T) {
+	done := make(chan struct{})
+	backend := newBackendWSServer(func(conn *websocket.Conn) {
+		defer close(done)
+		// Drop the TCP connection without sending a WS close frame.
+		// gorilla on the other side will surface this as CloseAbnormalClosure (1006).
+		conn.Close()
+	})
+	defer backend.Close()
+
+	ts, vk := newWSProxyServer(t, "ws"+strings.TrimPrefix(backend.URL, "http"))
+	client := dialTestWS(t, ts, "/testchain")
+	defer client.Close()
+
+	// proxyWebSocketCopy remaps 1006 to 1001 (Going Away) because 1006 must not
+	// be sent on the wire per RFC 6455.
+	code := wsCloseCode(client)
+	if code != websocket.CloseGoingAway {
+		t.Errorf("client expected close 1001 (remapped from 1006), got %d", code)
+	}
+
+	<-done
+	settle()
+
+	if !wsIsUnhealthy(t, vk) {
+		t.Error("endpoint must be marked WS-unhealthy after backend TCP drop (1006)")
+	}
+}
+
+// TestWSClose_Backend_InternalError verifies that a 1011 close from the backend
+// IS counted as a failure, since it signals an unexpected server error.
+// The client must receive 1011 and the endpoint must be marked WS-unhealthy.
+func TestWSClose_Backend_InternalError(t *testing.T) {
+	done := make(chan struct{})
+	backend := newBackendWSServer(func(conn *websocket.Conn) {
+		defer close(done)
+		conn.WriteMessage(websocket.CloseMessage,
+			websocket.FormatCloseMessage(websocket.CloseInternalServerErr, "internal error"))
+		time.Sleep(20 * time.Millisecond)
+		conn.Close()
+	})
+	defer backend.Close()
+
+	ts, vk := newWSProxyServer(t, "ws"+strings.TrimPrefix(backend.URL, "http"))
+	client := dialTestWS(t, ts, "/testchain")
+	defer client.Close()
+
+	code := wsCloseCode(client)
+	if code != websocket.CloseInternalServerErr {
+		t.Errorf("client expected close 1011, got %d", code)
+	}
+
+	<-done
+	settle()
+
+	if !wsIsUnhealthy(t, vk) {
+		t.Error("endpoint must be marked WS-unhealthy after backend 1011 (Internal Server Error)")
+	}
+}
+
+// --- Client-initiated closures ---
+
+// TestWSClose_Client_NormalClosure verifies that a client-initiated 1000 closure
+// does not count against the backend's health.
+func TestWSClose_Client_NormalClosure(t *testing.T) {
+	ready := make(chan struct{})
+	done := make(chan struct{})
+	backend := newBackendWSServer(func(conn *websocket.Conn) {
+		defer close(done)
+		close(ready)
+		conn.ReadMessage() // blocks until client closes
+		conn.Close()
+	})
+	defer backend.Close()
+
+	ts, vk := newWSProxyServer(t, "ws"+strings.TrimPrefix(backend.URL, "http"))
+	client := dialTestWS(t, ts, "/testchain")
+
+	<-ready
+	client.WriteMessage(websocket.CloseMessage,
+		websocket.FormatCloseMessage(websocket.CloseNormalClosure, ""))
+	client.Close()
+
+	<-done
+	settle()
+
+	if wsIsUnhealthy(t, vk) {
+		t.Error("endpoint must remain healthy after client-initiated 1000 close")
+	}
+}
+
+// TestWSClose_Client_AbnormalClosure verifies that a client TCP drop (1006 from
+// the client side) does not count against the backend's health.
+func TestWSClose_Client_AbnormalClosure(t *testing.T) {
+	ready := make(chan struct{})
+	done := make(chan struct{})
+	backend := newBackendWSServer(func(conn *websocket.Conn) {
+		defer close(done)
+		close(ready)
+		conn.ReadMessage()
+		conn.Close()
+	})
+	defer backend.Close()
+
+	ts, vk := newWSProxyServer(t, "ws"+strings.TrimPrefix(backend.URL, "http"))
+	client := dialTestWS(t, ts, "/testchain")
+
+	<-ready
+	// Drop TCP without WS close frame, aetherlay sees this as a client-side 1006.
+	client.Close()
+
+	<-done
+	settle()
+
+	if wsIsUnhealthy(t, vk) {
+		t.Error("endpoint must remain healthy after client TCP drop")
+	}
+}
+
+// TestWSClose_Client_GoingAway verifies that a client-initiated 1001 close does
+// not count against the backend's health.
+func TestWSClose_Client_GoingAway(t *testing.T) {
+	ready := make(chan struct{})
+	done := make(chan struct{})
+	backend := newBackendWSServer(func(conn *websocket.Conn) {
+		defer close(done)
+		close(ready)
+		conn.ReadMessage()
+		conn.Close()
+	})
+	defer backend.Close()
+
+	ts, vk := newWSProxyServer(t, "ws"+strings.TrimPrefix(backend.URL, "http"))
+	client := dialTestWS(t, ts, "/testchain")
+
+	<-ready
+	client.WriteMessage(websocket.CloseMessage,
+		websocket.FormatCloseMessage(websocket.CloseGoingAway, "client shutting down"))
+	client.Close()
+
+	<-done
+	settle()
+
+	if wsIsUnhealthy(t, vk) {
+		t.Error("endpoint must remain healthy after client-initiated 1001 close")
+	}
+}


### PR DESCRIPTION
This makes sure the connection is always properly closed by aetherlay whenever the remote endpoint closes it for any reason. In some cases, we track the closure as an issue, but we always close the connection.

This should fix an issue where the end user has a socket open but no data flows through it. I have to run more tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved WebSocket failure semantics so backend "graceful" closes are not treated as errors while unexpected backend errors mark endpoints unhealthy.
  * Distinguish echoed close frames from client-initiated disconnects to avoid false health failures.
  * Client disconnects and drops are handled gracefully without marking endpoints unhealthy.

* **Tests**
  * Added integration tests covering various backend and client WebSocket close codes and health updates.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/project-aethermesh/aetherlay/pull/34)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->