### PR TITLE
feat: allow skipping sync checks per endpoint

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -21,6 +21,7 @@ type Endpoint struct {
 	Provider          string             `json:"provider"`            // Name of the RPC provider (e.g., "alchemy", "infura")
 	RateLimitRecovery *RateLimitRecovery `json:"rate_limit_recovery"` // Rate limit recovery configuration (optional)
 	Role              string             `json:"role"`                // Role of the endpoint: "primary" or "fallback"
+	SkipSyncCheck     bool               `json:"skip_sync_check"`     // Skip eth_syncing check for this endpoint (default: false)
 	Type              string             `json:"type"`                // Type of node: "full" or "archive"
 	HTTPURL           string             `json:"http_url"`            // HTTP/HTTPS URL for RPC requests
 	WSURL             string             `json:"ws_url"`              // WebSocket URL for real-time connections

--- a/internal/health/checker.go
+++ b/internal/health/checker.go
@@ -699,10 +699,10 @@ func (c *Checker) checkHTTPHealth(ctx context.Context, chain, endpointID string,
 	blockResult, blockErr := c.makeRPCCall(ctx, endpoint.HTTPURL, "eth_blockNumber", chain, endpointID)
 	c.incrementHealthRequestCount(ctx, chain, endpointID)
 
-	// Only make the eth_syncing call if sync status checking is enabled
+	// Only make the eth_syncing call if sync status checking is enabled and not skipped for this endpoint
 	var syncResult any
 	var syncErr error
-	if c.healthCheckSyncStatus {
+	if c.healthCheckSyncStatus && !endpoint.SkipSyncCheck {
 		syncResult, syncErr = c.makeRPCCall(ctx, endpoint.HTTPURL, "eth_syncing", chain, endpointID)
 		c.incrementHealthRequestCount(ctx, chain, endpointID)
 	}
@@ -749,10 +749,10 @@ func (c *Checker) checkWSHealth(ctx context.Context, chain, endpointID string, e
 	blockResult, blockErr := c.makeWSRPCCall(endpoint.WSURL, "eth_blockNumber", chain, endpointID)
 	c.incrementHealthRequestCount(ctx, chain, endpointID)
 
-	// Only make the eth_syncing call if sync status checking is enabled
+	// Only make the eth_syncing call if sync status checking is enabled and not skipped for this endpoint
 	var syncResult any
 	var syncErr error
-	if c.healthCheckSyncStatus {
+	if c.healthCheckSyncStatus && !endpoint.SkipSyncCheck {
 		syncResult, syncErr = c.makeWSRPCCall(endpoint.WSURL, "eth_syncing", chain, endpointID)
 		c.incrementHealthRequestCount(ctx, chain, endpointID)
 	}


### PR DESCRIPTION
Networks like Tempo don't support `eth_syncing`, causing the endpoints to never show up as available.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a per-endpoint option to skip the syncing status check during health checks.
  * Health checks still verify block number availability, while allowing selected endpoints to avoid syncing-related failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->